### PR TITLE
Prune down values for OpenLDAP

### DIFF
--- a/values/operations/openldap.yml
+++ b/values/operations/openldap.yml
@@ -1,28 +1,3 @@
-# Default values for openldap.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
-replicaCount: 1
-
-# Define deployment strategy - IMPORTANT: use rollingUpdate: null when use Recreate strategy.
-# It prevents from merging with existing map keys which are forbidden.
-strategy: {}
-  # type: RollingUpdate
-  # rollingUpdate:
-  #   maxSurge: 1
-  #   maxUnavailable: 0
-  #
-  # or
-  #
-  # type: Recreate
-  # rollingUpdate: null
-image:
-  # From repository https://github.com/osixia/docker-openldap
-  repository: osixia/openldap
-  tag: 1.2.4
-  pullPolicy: IfNotPresent
-
-# Spcifies an existing secret to be used for admin and config user passwords
 existingSecret: openldap-password
 
 # settings for enabling TLS
@@ -33,23 +8,8 @@ tls:
     enabled: true
     secret: openldap-server-tls  # The name of a generic secret to use for custom CA certificate (ca.crt)
 
-## Add additional labels to all resources
-extraLabels: {}
-## Add additional annotations to pods
-podAnnotations: {}
 service:
-  annotations: {}
-  clusterIP: ""
-
-  ldapPort: 389
-  sslLdapPort: 636  # Only used if tls.enabled is true
-  ## List of IP addresses at which the service is available
-  ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
-  ##
-  externalIPs: []
-
   loadBalancerIP: "10.16.3.4"
-  loadBalancerSourceRanges: []
   type: LoadBalancer
 
 # Default configuration for openldap as environment variables. These get injected directly in the container.
@@ -63,13 +23,6 @@ env:
   LDAP_REMOVE_CONFIG_AFTER_SETUP: "true"
   LDAP_TLS_VERIFY_CLIENT: "try"
 
-# Default Passwords to use, stored as a secret. If unset, passwords are auto-generated.
-# You can override these at install time with
-# helm install openldap --set openldap.adminPassword=<passwd>,openldap.configPassword=<passwd>
-# adminPassword: admin
-# configPassword: config
-
-# Custom openldap configuration files used to override default settings
 customLdifFiles:
   00-org-units.ldif: |-
     dn: o=homelab,{{ LDAP_BASE_DN }}
@@ -177,43 +130,4 @@ customLdifFiles:
 ## Persist data to a persistent volume
 persistence:
   enabled: true
-  ## database data Persistent Volume Storage Class
-  ## If defined, storageClassName: <storageClass>
-  ## If set to "-", storageClassName: "", which disables dynamic provisioning
-  ## If undefined (the default) or set to null, no storageClassName spec is
-  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-  ##   GKE, AWS & OpenStack)
-  ##
   storageClass: vsan
-  accessMode: ReadWriteOnce
-  size: 8Gi
-  # existingClaim: ""
-
-resources: {}
- # requests:
- #   cpu: "100m"
- #   memory: "256Mi"
- # limits:
- #   cpu: "500m"
- #   memory: "512Mi"
-
-initResources: {}
- # requests:
- #   cpu: "100m"
- #   memory: "128Mi"
- # limits:
- #   cpu: "100m"
- #   memory: "128Mi"
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
-
-## test container details
-test:
-  enabled: false
-  image:
-    repository: dduportal/bats
-    tag: 0.4.0


### PR DESCRIPTION
TL;DR
-----

Only set values we change when installing OpenLDAP

Details
-------

I originally used the full `values.yaml` from the OpenLDAP Helm
chart as a baseline file that I edited for my install. This meant
I set a lot of values to their defaults and wouldn't be able to
take advataged of changes to those defaults (or added values) in
newer version fo the chart.

This change fixes that, but only setting the values I want to
control. This is part of shifting all the values files in the
codebase to that model.
