### PR TITLE
Create and use the proper certificate for Minio

### DIFF
--- a/terraform/operations/variables.tf
+++ b/terraform/operations/variables.tf
@@ -27,7 +27,7 @@ locals {
     base_dn = format("dc=%s", join(",dc=",split(".",var.domain)))
     subdomain = data.terraform_remote_state.infrastructure.outputs.subdomain
     ldap_host = "directory.${local.subdomain}"
-    minio_host = "local.${local.subdomain}"
+    minio_host = "s3.${local.subdomain}"
 
     directories = {
         config = "${var.project_root}/config"


### PR DESCRIPTION
TL;DR
-----

Fix issue with Minio showing an invalid certificate

Details
-------

Minio was showing a certificate for `local.lab.crdant.net` 
rather than `s3.lab.crdant.net`. That was the certificate that
Terraform created since the host name was set incorrectlty.
This change updates the value to the correct name.
