### PR TITLE
Create the tools cluster with Terraform

### DIFF
--- a/config/tools/namespace.yml
+++ b/config/tools/namespace.yml
@@ -5,7 +5,7 @@ metadata:
   datacenter: garage
   cluster: homelab
 spec:
-  namespace: toolchain
+  namespace: tools
   description: 
   access_list:
   - role: EDIT

--- a/terraform/tools/cluster.tf
+++ b/terraform/tools/cluster.tf
@@ -1,0 +1,48 @@
+# resource "kubernetes_manifest" "cluster" {
+#  provider = kubernetes-alpha
+#  manifest = yamldecode(file("${path.module}/cluster.yml"))
+#}
+
+resource "null_resource" "supervisor_cluster" {
+  provisioner "local-exec" { 
+    command = "tkg add management-cluster && tkg set management-cluster supervisor.lab.crdant.net"
+  }
+} 
+
+resource "null_resource" "tools_cluster" {
+  provisioner "local-exec" { 
+    command = "tkg create cluster ${var.cluster_name} --plan=${var.cluster_plan} --namespace=${var.namespace} --kubernetes-version=${var.kubernetes_version} --worker-machine-count=${var.worker_nodes}"
+    environment = {
+      CONTROL_PLANE_STORAGE_CLASS = var.storage_class
+      WORKER_STORAGE_CLASS = var.storage_class
+      DEFAULT_STORAGE_CLASS = var.storage_class
+      STORAGE_CLASSES = var.storage_class
+      CONTROL_PLANE_VM_CLASS = var.control_plane_vm_class
+      WORKER_VM_CLASS = var.worker_vm_class
+      SERVICE_CIDR = var.services_cidr
+      CLUSTER_CIDR = var.cluster_cidr
+    }
+  }
+
+  depends_on = [
+    null_resource.supervisor_cluster
+  ]
+} 
+
+data "kubernetes_secret" "kubeconfig" {
+  metadata {
+    name = "${var.cluster_name}-kubeconfig"
+    namespace = var.namespace
+  }
+
+  depends_on = [
+    null_resource.tools_cluster
+  ]
+}
+
+resource "local_file" "kubeconfig" {
+  content = data.kubernetes_secret.kubeconfig.data.value
+  file_permission = "0600"
+  filename = "${local.directories.secrets}/${var.cluster_name}.kubeconfig"
+}
+

--- a/terraform/tools/variables.tf
+++ b/terraform/tools/variables.tf
@@ -1,0 +1,81 @@
+variable "email" {
+    type = string
+}
+
+variable "project_root" {
+    type = string
+}
+
+variable "namespace" {
+    type = string
+    default = "tools"
+}
+
+variable "kubeconfig" {
+    type = string
+}
+
+variable "cluster_name" {
+    type = string
+    default = "tools"
+}
+
+variable "cluster_plan" {
+    type = string
+    default = "dev"
+}
+
+variable "worker_nodes" {
+    type = number
+    default = 3
+}
+
+variable "kubernetes_version" {
+    type = string
+    default = "v1.17.7+vmware.1"
+}
+
+
+variable "control_plane_vm_class" { 
+    type = string
+    default = "best-effort-small"
+}
+
+variable "worker_vm_class" { 
+    type = string
+    default = "best-effort-medium"
+}
+
+variable "storage_class" {
+    type = string
+    default = "vsan"
+}
+
+variable "services_cidr" {
+    type = string
+    default = "10.208.0.0/12"
+}
+
+variable "cluster_cidr" {
+    type = string
+    default = "172.18.0.0/16"
+}
+
+locals {
+    subdomain = data.terraform_remote_state.infrastructure.outputs.subdomain
+    ldap_host = "directory.${local.subdomain}"
+    minio_host = "s3.${local.subdomain}"
+
+    directories = {
+        config = "${var.project_root}/config"
+        values = "${var.project_root}/values"
+        secrets = "${var.project_root}/secrets"
+        policy  = "${var.project_root}/etc/vault/policy"
+        overlay = "${var.project_root}/overlay"
+    }
+
+    helm = { 
+        stable = "https://kubernetes-charts.storage.googleapis.com/"
+        bitnami = "https://charts.bitnami.com/bitnami" 
+    }
+}


### PR DESCRIPTION
TL;DR
-----

Use Terraform to create a cluster for shared tooling

Details
-------

Uses Terraform to drive the `tkg` CLI to create a cluster for
share tools. Right now, there are two resources of type 
`null_resource` that use a local provisioner to first set up
the `tkg` CLI to use the supervisdor cluster, and then to 
create the cluster with `tkg create cluster`.

The second of these null resources was intended to use a 
`kubernetes_manifest` resource, but as of now the supervisor
cluster is not compatible with that approach. Getting there
requires that either the Tanzu Kubernetes Cluster controller
be updated to support a server-side dry run, or that the 
alpha Terraform provider for Kubernetes manifests be changed
to support a client side plan. 

Since my lab is behind by one patch level and there is an 
open issue with the manifest terrform provider, it's possible
that one or both of these issues will be resolved soon.

