### PR TITLE
Don't use Terraform for the tools cluster

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -4,7 +4,7 @@ SECRETS_DIR=${PROJECT_DIR}/secrets
 
 watch_file "${SECRETS_DIR}/vault.crt"
 watch_file "${SECRETS_DIR}/govc.env"
-watch_file "${SECRETS_DIR}/kubeconfig"
+watch_file "${SECRETS_DIR}/supervisor.kubeconfig"
 
 export TF_VAR_vault_ldap_bind_password=widely-underlie-daughter-crosier-schooner
 export TF_VAR_vault_ldap_bind_dn=uid=vault,ou=systems,o=homelab,dc=crdant,dc=net
@@ -27,6 +27,6 @@ if [ -f "${SECRETS_DIR}/govc.env" ] ; then
   set +a
 fi
 
-if [ -f "${SECRETS_DIR}/kubeconfig" ] ; then
-  export KUBECONFIG="${SECRETS_DIR}/kubeconfig"  
+if [ -f "${SECRETS_DIR}/supervisor.kubeconfig" ] ; then
+  export KUBECONFIG="${SECRETS_DIR}/supervisor.kubeconfig"  
 fi

--- a/terraform/tools/cert-manager.tf
+++ b/terraform/tools/cert-manager.tf
@@ -3,10 +3,6 @@ resource "kubernetes_namespace" "cert_manager" {
   metadata {
     name = "cert-manager"
   }
-
-  depends_on = [
-    local_file.kubeconfig
-  ]
 }
 
 module "cert_manager_chart" {

--- a/terraform/tools/cluster.tf
+++ b/terraform/tools/cluster.tf
@@ -3,51 +3,6 @@
 #  manifest = yamldecode(file("${path.module}/cluster.yml"))
 #}
 
-resource "null_resource" "supervisor_cluster" {
-  provisioner "local-exec" { 
-    command = "tkg add management-cluster && tkg set management-cluster supervisor.lab.crdant.net"
-  }
-} 
-
-resource "null_resource" "tools_cluster" {
-  provisioner "local-exec" { 
-    command = "tkg create cluster ${var.cluster_name} --plan=${var.cluster_plan} --namespace=${var.namespace} --kubernetes-version=${var.kubernetes_version} --worker-machine-count=${var.worker_nodes}"
-    environment = {
-      CONTROL_PLANE_STORAGE_CLASS = var.storage_class
-      WORKER_STORAGE_CLASS = var.storage_class
-      DEFAULT_STORAGE_CLASS = var.storage_class
-      STORAGE_CLASSES = var.storage_class
-      CONTROL_PLANE_VM_CLASS = var.control_plane_vm_class
-      WORKER_VM_CLASS = var.worker_vm_class
-      SERVICE_CIDR = var.services_cidr
-      CLUSTER_CIDR = var.cluster_cidr
-    }
-  }
-
-  depends_on = [
-    null_resource.supervisor_cluster
-  ]
-} 
-
-data "kubernetes_secret" "kubeconfig" {
-  provider = kubernetes.supervisor_cluster
-
-  metadata {
-    name = "${var.cluster_name}-kubeconfig"
-    namespace = var.namespace
-  }
-
-  depends_on = [
-    null_resource.tools_cluster
-  ]
-}
-
-resource "local_file" "kubeconfig" {
-  content = data.kubernetes_secret.kubeconfig.data.value
-  file_permission = "0600"
-  filename = "${local.directories.secrets}/${var.cluster_name}.kubeconfig"
-}
-
 resource "kubernetes_cluster_role_binding" "default_psp" {
   provider = kubernetes.tools_cluster
 
@@ -65,7 +20,4 @@ resource "kubernetes_cluster_role_binding" "default_psp" {
     api_group = "rbac.authorization.k8s.io"
   }
 
-  depends_on = [
-    local_file.kubeconfig
-  ]
 }

--- a/terraform/tools/providers.tf
+++ b/terraform/tools/providers.tf
@@ -7,7 +7,6 @@ provider "kubernetes" {
 provider "kubernetes" {
   alias = "tools_cluster"
   config_path = "${local.directories.secrets}/${var.namespace}.kubeconfig"
-  config_context = "kubernetes-admin@${var.namespace}"
 }
 
 provider "helm" {

--- a/terraform/tools/variables.tf
+++ b/terraform/tools/variables.tf
@@ -11,56 +11,6 @@ variable "namespace" {
     default = "tools"
 }
 
-variable "kubeconfig" {
-    type = string
-}
-
-variable "cluster_name" {
-    type = string
-    default = "tools"
-}
-
-variable "cluster_plan" {
-    type = string
-    default = "dev"
-}
-
-variable "worker_nodes" {
-    type = number
-    default = 3
-}
-
-variable "kubernetes_version" {
-    type = string
-    default = "v1.17.7+vmware.1"
-}
-
-
-variable "control_plane_vm_class" { 
-    type = string
-    default = "best-effort-small"
-}
-
-variable "worker_vm_class" { 
-    type = string
-    default = "best-effort-medium"
-}
-
-variable "storage_class" {
-    type = string
-    default = "vsan"
-}
-
-variable "services_cidr" {
-    type = string
-    default = "10.208.0.0/12"
-}
-
-variable "cluster_cidr" {
-    type = string
-    default = "172.18.0.0/16"
-}
-
 locals {
     subdomain = data.terraform_remote_state.infrastructure.outputs.subdomain
     ldap_host = "directory.${local.subdomain}"


### PR DESCRIPTION
TL;DR
-----

Remove Terraform that created the tools cluster

Details
-------

Creating the tools cluster with Terrform was a bit cludgey, and it
started to feel like a bit more trouble that it was worth. There
were two main challenges:

1. There wasn't any way to work with TKG other than to use a
   null resources and local provisioner. That's always a bit of
   a code smell but seemed workable...until it seemed less so.
2. Connecting to the tools cluster in the same Terraform that
   created it created circular references that were stretching
   what Terraform is capable of. Eventually it was clear that
   it wasn't going to work.

It was possible to split it out into it's own seperate stage of
Terraforming, but that started to feel awkward when the only
things in it were going to be null resource hacks.